### PR TITLE
fix iipyper dependency to point to git closes #1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ numpy = "^1.23"
 pandas = "^1.5"
 tqdm = "^4.64"
 sf2utils = "^0.9"
-iipyper = {path = "../iipyper", develop = true}
+iipyper = {git = "https://github.com/Intelligent-Instruments-Lab/iipyper.git" , develop = true}
 appdirs = "^1.4.4"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Hi folks---what a great system! @YichenWangs and I were looking at using it for something but couldn't get it installed because the `iipyper` dependency is current set to `../iipyper`.

I thought it would make more sense for this to just point to the `iipyper` repo on Github, so this commit just changes the dependency location in `pyproject.toml`.

With this, we are able to run `poetry install` and then run the app with `poetry run python -m notochord` and now we can use it in our study.

Would it be ok to have the dependency this way in the main repo?